### PR TITLE
Update app name in README integration example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ For each authentication provider, the top portion of your REST API settings.py f
         # OAuth
         'oauth2_provider',
         'social_django',
-        'rest_framework_social_oauth2',
+        'drf_social_oauth2',
     )
 
     TEMPLATES = [


### PR DESCRIPTION
Thanks for keeping this project alive! There was still a reference to the old project in the README, from the integration example.