### PR TITLE
fix: update url import to match Django > 1.11 requirement

### DIFF
--- a/drf_social_oauth2/urls.py
+++ b/drf_social_oauth2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from oauth2_provider.views import AuthorizationView
 
 from drf_social_oauth2.views import (
@@ -12,13 +12,13 @@ from drf_social_oauth2.views import (
 app_name = 'drfso2'
 
 urlpatterns = [
-    url(r'^authorize/?$', AuthorizationView.as_view(), name='authorize'),
-    url(r'^token/?$', TokenView.as_view(), name='token'),
-    url('', include('social_django.urls', namespace='social')),
-    url(r'^convert-token/?$', ConvertTokenView.as_view(), name='convert_token'),
-    url(r'^revoke-token/?$', RevokeTokenView.as_view(), name='revoke_token'),
-    url(r'^invalidate-sessions/?$', invalidate_sessions, name='invalidate_sessions'),
-    url(
+    re_path(r'^authorize/?$', AuthorizationView.as_view(), name='authorize'),
+    re_path(r'^token/?$', TokenView.as_view(), name='token'),
+    re_path('', include('social_django.re_paths', namespace='social')),
+    re_path(r'^convert-token/?$', ConvertTokenView.as_view(), name='convert_token'),
+    re_path(r'^revoke-token/?$', RevokeTokenView.as_view(), name='revoke_token'),
+    re_path(r'^invalidate-sessions/?$', invalidate_sessions, name='invalidate_sessions'),
+    re_path(
         r'^disconnect-backend/?$',
         DisconnectBackendView.as_view(),
         name='disconnect_backend',


### PR DESCRIPTION
This PR provides a fix for #76 by importing `re_path` from `django.urls` as opposed to the now deprecated `url` from `django.conf.urls`

Fixes #76 