### PR TITLE
Handle IntegrityError for Duplicate Email Entries

### DIFF
--- a/drf_social_oauth2/views.py
+++ b/drf_social_oauth2/views.py
@@ -133,6 +133,22 @@ class ConvertTokenView(CsrfExemptMixin, OAuthLibMixin, APIView):
                 {'access_denied': f'The token you provided is invalid or expired.'},
                 status=HTTP_400_BAD_REQUEST,
             )
+        except IntegrityError as e:
+            if 'email' in str(e) and 'already exists' in str(e):
+                return Response(
+                    {'error': 'A user with this email already exists.'},
+                    status=HTTP_400_BAD_REQUEST,
+                )
+            else:
+                return Response(
+                    {'error': 'Database error.'},
+                    status=HTTP_400_BAD_REQUEST,
+                )
+        except Exception as e:
+            return Response(
+                {'error': str(e)},
+                status=HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         return Response(data=json_loads(body), status=status)
 


### PR DESCRIPTION
# Description

This pull request includes a change to our error handling logic to account for `IntegrityError` exceptions that are raised when a duplicate email entry is attempted. 

When a `IntegrityError` is caught, the code checks if it's due to a duplicate email. If so, it returns a 400 Bad Request response with an appropriate error message. If the `IntegrityError` is for a different reason, it still returns a 400 Bad Request response, but with a more general 'Database error' message.

Fixes # (issue)

## Checklist

- [x] Do unit tests run with no errors?
- [x] Has coverage not decreased?
- [x] Is your code concise and clean?
- [ ] Are the conf.py and installation sphinx updated with the new version?
- [ ] Is the __init__.py __version__ variable updated?
