### PR TITLE
chore: switch from jose to pyjwt

### DIFF
--- a/drf_social_oauth2/__init__.py
+++ b/drf_social_oauth2/__init__.py
@@ -8,8 +8,6 @@ and a ton more!
 
 __version__ = '2.1.3'
 
-
-
 try:
     from secrets import SystemRandom
 except ImportError:

--- a/drf_social_oauth2/__init__.py
+++ b/drf_social_oauth2/__init__.py
@@ -8,6 +8,8 @@ and a ton more!
 
 __version__ = '2.1.3'
 
+
+
 try:
     from secrets import SystemRandom
 except ImportError:
@@ -27,7 +29,7 @@ def generate_token(request, length=30, chars=UNICODE_ASCII_CHARACTER_SET):
     why SystemRandom is used instead of the default random.choice method.
     """
     from django.conf import settings
-    from jose import jwt
+    import jwt
 
     rand = SystemRandom()
     secret = getattr(settings, 'SECRET_KEY')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 include = '\.pyi?$'
 skip-string-normalization = true
 requires = [
-    'python-jose[cryptography]>=3.2.0',
+    'PyJWT>=2.8.0',
     'python-secrets>=3.9.2',
 ]
 exclude = '''

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,5 +6,5 @@ social-auth-app-django>=3.1.0
 pytest-mock==3.6.1
 coverage==6.2
 psycopg2-binary==2.9.3
-python-jose[cryptography]>=3.3.0
 model_bakery==1.11.0
+PyJWT==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'djangorestframework>=3.10.3',
         'django-oauth-toolkit>=0.12.0',
         'social-auth-app-django>=3.1.0',
-        'python-jose[cryptography]>=3.3.0',
+        'PyJWT>=2.8.0'
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
# Description
The [python-jose](https://github.com/mpdavis/python-jose) project is not being maintained anymore.

The project is using an outdated dependency: [ecdsa](https://github.com/tlsfuzzer/python-ecdsa) 

Fixes # (issue)
[Minerva timing attack on P-256 in python-ecdsa](https://github.com/advisories/GHSA-wj6h-64fc-37mp)

There already is an issue on the python-jose project, with no reaction by the authors:
https://github.com/mpdavis/python-jose/issues/341

---

This PR switches python-jose to [PyJWT](https://github.com/jpadilla/pyjwt)

## Checklist

- [x] Do unit tests run with no errors?
- [x] Has coverage not decreased?
- [x] Is your code concise and clean?
- [x] Are the conf.py and installation sphinx updated with the new version?
- [x] Is the __init__.py __version__ variable updated?
