### PR TITLE
Add PyPI downloads badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,11 @@ Welcome to DRF-Social-OAuth2
 .. image:: https://www.codefactor.io/repository/github/wagnerdelima/drf-social-oauth2/badge
     :target: https://www.codefactor.io/repository/github/wagnerdelima/drf-social-oauth2/badge
 
+.. image:: https://static.pepy.tech/badge/drf-social-oauth2
+   :target: https://pepy.tech/project/drf-social-oauth2
+
+
+
 Installation
 ------------
 


### PR DESCRIPTION
In the README file, a new badge has been added to show the number of PyPI downloads for the package. This change aims to provide users an easy way to see the popularity and widespread use of the drf-social-oauth2 package.

# Description
Please include changes' summary that your pull request entails.

Fixes # (issue)

## Checklist

- [ ] Do unit tests run with no errors?
- [ ] Has coverage not decreased?
- [ ] Is your code concise and clean?
- [ ] Are the conf.py and installation sphinx updated with the new version?
- [ ] Is the __init__.py __version__ variable updated?
